### PR TITLE
Add link to Shell materials

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@ etherpad: https://etherpad.mozilla.org/2015-07-06-scipy
   <div class="col-md-6">
     <h3>Day 1</h3>
     <table class="table table-striped">
-      <tr> <td>08:00</td>  <td>Automating tasks with the Unix shell</td> </tr>
+      <tr> <td>08:00</td>  <td><a href='http://jenshnielsen.github.io/2015-07-06-scipy-shell-novice/'> Automating tasks with the Unix shell</a></td> </tr>
       <tr> <td>10:30</td> <td>Coffee</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
       <tr> <td>13:00</td>  <td>Building programs with Python</td> </tr>


### PR DESCRIPTION
I have put up the shell materials is a separate  repository is that OK? Seems to create less confusion.

I will add @jiffyclub and @wrightaprilm to that repository

BTW: the rendering of https://jiffyclub.github.io/2015-07-06-scipy/ is broken for me at the moment
